### PR TITLE
Fix single star globs local

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,8 +33,22 @@ jobs:
     - name: Test
       run: go test -v ./...
       
-    - name: Vet
-      run: go vet -v ./...
 
-    - name: fmt
-      run: diff <(gofmt -d .) <(printf "")
+  lint-vet:
+    env:
+      CGO_ENABLED: 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Vet
+        run: go vet -v ./...
+
+      - name: fmt
+        run: diff <(gofmt -d .) <(printf "")

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.19.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       CGO_ENABLED: 0
     runs-on: ${{ matrix.os }}

--- a/filepathx.go
+++ b/filepathx.go
@@ -29,7 +29,7 @@ func (globs Globs) Expand() ([]string, error) {
 		var hits []string
 		var hitMap = map[string]bool{}
 		for _, match := range matches {
-			paths, err := filepath.Glob(match + glob)
+			paths, err := filepath.Glob(filepath.Join(match, glob))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Single star into double star did not work as expected.

Pattern `a/b/*/e.f/**` would not match `a/b/c/e.f/g` since the top level glob would be performed on a path ending with a `/`. Using `filepath.Join(match, glob)` will remove the trailing slash.

Two tests included for regression tests. And as a side bonus tests will now also pass on Windows.